### PR TITLE
Rename Frameworks to Frameworks & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,4 +761,3 @@
     + [simpleCart.js](http://simplecartjs.org/)
     + [Aware.js](http://xoxco.com/projects/code/aware/) is a simple jQuery plugin that allows a site to customize and personalize the display of content based on a reader's behavior without requiring login, authentication, or any server-side processing.
     + [How to directly upload files to Amazon S3 from your client side web app](http://codeartists.com/post/36892733572/how-to-directly-upload-files-to-amazon-s3-from-your)
-


### PR DESCRIPTION
Even though some sources may suggest it, jQuery's not a framework.
