### PR TITLE
Added links to JSLint, JSHint and JSLint Error Explanations site

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@
         + [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
         + [Github JavaScript Styleguide](https://github.com/styleguide/javascript)
         + [Wordpress JavaScript Coding Standards](http://make.wordpress.org/core/handbook/coding-standards/javascript/)
+        + [JSLint](http://jslint.com/) for detecting errors or problems by static analysis of JavaScript programs.
+        + [JSHint](http://jshint.com/) for more flexible static analysis of JavaScript programs.
+        + [JSLint Error Explanations](http://jslinterrors.com) for explanations of the warnings given by JSLint and JSHint.
         + Extensions
             + [RubyJS](http://rubyjs.org/) is a JavaScript implementation of all methods from Ruby classes like Array, String, Numbers, Time and more.
             + [Mout](http://moutjs.com/) is a collection of modular JavaScript utilities that can be used in the browser as AMD modules or on node.js (without any overhead).


### PR DESCRIPTION
There were no links to any static analysis tools for JavaScript. In my opinion, these can play a very important role in any JS developer workflow. I've added links for JSLint, JSHint and http://jslinterrors.com (which offers explanations for the errors/warnings given by JSLint and JSHint).
