### PR TITLE
Add GA Dash to guides section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     + [Codeschool](https://www.codeschool.com/) teaches web technologies in the comfort of your browser with video lessons, coding challenges, and screencasts.
     + [TheExpressiveWeb](http://beta.theexpressiveweb.com/): This site by Adobe is a resource and showcase of some of the newest, and most expressive features being added to the web today.
     + [Treehouse](http://teamtreehouse.com/): Learn HTML, CSS, iPhone apps and more.
+    + [General Assembly Dash](https://dash.generalassemb.ly): Learn HTML, CSS, and Javascript through fun projects you do in your browser.
 + Architecture
     + [Web Components](http://w3c.github.io/webcomponents/explainer/): the component model for the Web.
     + [BEM](http://bem.info/): Methodology aimed at achieving fast to develop long-lived projects, team scalability, and code reuse.


### PR DESCRIPTION
Adds a link to [General Assembly's Dash](https://dash.generalassemb.ly) which teaches HTML, CSS, and Javascript through fun projects you do in your browser.
